### PR TITLE
Check if a post was successfully made the day before

### DIFF
--- a/water_thread_wrapup.py
+++ b/water_thread_wrapup.py
@@ -25,7 +25,7 @@ with open(path+'daily_thread.txt', 'r+') as f:
     f.close()
 
 s = r.get_submission(submission_id = thread)
-if time.gmtime(s.created_utc()) + 1 != time.gmtime()[2]:
+if time.gmtime(s.created_utc())[2] + 1 != time.gmtime()[2]:
     print "Thread too old. Skipping today"
     exit()
 s.lock()

--- a/water_thread_wrapup.py
+++ b/water_thread_wrapup.py
@@ -25,7 +25,9 @@ with open(path+'daily_thread.txt', 'r+') as f:
     f.close()
 
 s = r.get_submission(submission_id = thread)
-if time.gmtime(s.created_utc())[2] + 1 != time.gmtime()[2]:
+# If the last post isn't from today, just do nothing
+# It at least avoids double-watering this way
+if time.gmtime(s.created_utc)[2] + 1 != time.gmtime()[2]:
     exit("Thread too old. Skipping today")
 s.lock()
 s.unsticky()

--- a/water_thread_wrapup.py
+++ b/water_thread_wrapup.py
@@ -25,6 +25,9 @@ with open(path+'daily_thread.txt', 'r+') as f:
     f.close()
 
 s = r.get_submission(submission_id = thread)
+if time.gmtime(s.created_utc()) + 1 != time.gmtime()[2]:
+    print "Thread too old. Skipping today"
+    exit()
 s.lock()
 s.unsticky()
 

--- a/water_thread_wrapup.py
+++ b/water_thread_wrapup.py
@@ -26,8 +26,7 @@ with open(path+'daily_thread.txt', 'r+') as f:
 
 s = r.get_submission(submission_id = thread)
 if time.gmtime(s.created_utc())[2] + 1 != time.gmtime()[2]:
-    print "Thread too old. Skipping today"
-    exit()
+    exit("Thread too old. Skipping today")
 s.lock()
 s.unsticky()
 


### PR DESCRIPTION
If the bot finds that the most recent post was not made within the past 24 hours, it just exits nicely without doing a bunch of excess work. This could be considered sub-ideal, since the voters could edit their votes and change the outcome, but in practice not enough people are doing this. At least this way, we would avoid a double-watering scenario. 