### PR TITLE
Remove old Reddit credential fields, the password is no longer valid

### DIFF
--- a/daily_water_thread.py
+++ b/daily_water_thread.py
@@ -7,9 +7,6 @@ import config as c
 import post_templates as posts
 #import gpio_out as g
 
-REDDIT_USERNAME = 'takecareofmyplant'
-REDDIT_PASSWORD = 'hunter2'
-
 # Set-up
 r = c.getReddit()
 sr = c.getSubReddit(r)

--- a/outstanding_gardeners.py
+++ b/outstanding_gardeners.py
@@ -6,9 +6,6 @@ import config as c
 
 from collections import Counter
 
-REDDIT_USERNAME = 'takecareofmyplant'
-REDDIT_PASSWORD = 'hunter2'
-
 path = c.pathPrefix()
 
 r = c.getReddit()


### PR DESCRIPTION
In the `daily_water_thread.py` and `outstanding_gardeners.py` files, there are two fields named `REDDIT_USERNAME` and `REDDIT_PASSWORD`.

These two fields are not used anywhere in this file or in any other file as part of this project, so it makes sense to remove these credentials. Also, credentials should never be out in the open anyway.